### PR TITLE
Record midi clip, validate with clips.size()

### DIFF
--- a/include/core/app.hh
+++ b/include/core/app.hh
@@ -19,12 +19,6 @@ struct App {
         Normal,
         Insert,
     };
-    App(te::Engine &engine, te::Edit &edit);
-    void Render(Interface& interface);
-    void HandleEvent(const Event& event);
-
-    void SetCurrentTrack(size_t track_app);
-    void AddTrack();
 
     ScreenState screen_state_ = ScreenState::Timeline;
     Mode mode_ = Mode::Normal;
@@ -45,6 +39,14 @@ struct App {
         Color{0xdd, 0xe6, 0x63, 0xff},
         Color{0x7d, 0x54, 0x39, 0xff},
     };
+
+    // functions
+    App(te::Engine &engine, te::Edit &edit);
+    void Render(Interface& interface);
+    void HandleEvent(const Event& event);
+
+    void SetCurrentTrack(size_t track_app);
+    void AddTrack();
 };
 
 } // namespace box

--- a/src/core/timeline.cc
+++ b/src/core/timeline.cc
@@ -33,6 +33,26 @@ void Timeline:: Render(Interface &interface)
     }
 }
 
+inline bool isTrackArmed (te::AudioTrack& t, int position = 0)
+{
+    auto& edit = t.edit;
+    for (auto instance : edit.getAllInputDevices())
+        if (instance->isOnTargetTrack (t, position))
+            return instance->isRecordingEnabled (t);
+
+    return false;
+}
+
+inline bool trackHasInput (te::AudioTrack& t, int position = 0)
+{
+    auto& edit = t.edit;
+    for (auto instance : edit.getAllInputDevices())
+        if (instance->isOnTargetTrack (t, position))
+            return true;
+
+    return false;
+}
+
 void Timeline:: HandleEvent(const Event &event) 
 {
     switch (screen_state_) 

--- a/src/core/timeline.cc
+++ b/src/core/timeline.cc
@@ -80,6 +80,9 @@ void Timeline:: HandleEvent(const Event &event)
                 break;
             case KEY_P:
                 LOG_VAR(APP->edit_.getTransport().getCurrentPosition());
+                LOG_VAR(APP->tracks_[APP->current_track_]->track_.getClips().size());
+                LOG_VAR(isTrackArmed(APP->tracks_[APP->current_track_]->track_));
+                LOG_VAR(trackHasInput(APP->tracks_[APP->current_track_]->track_));
                 break;
             case KEY_R:
                 {
@@ -88,7 +91,8 @@ void Timeline:: HandleEvent(const Event &event)
                     LOG_VAR(transport.isRecording());
                     if (transport.isRecording())
                     {
-                        transport.stop(true, false);
+                        transport.stop(false, false); // TODO should this discard?
+                        te::EditFileOperations (APP->edit_).save(true, true, false);
                     }
                     else
                     {
@@ -96,6 +100,16 @@ void Timeline:: HandleEvent(const Event &event)
                     }
                 }
                 break;
+            case KEY_T:
+                auto &transport = APP->edit_.getTransport();
+                if (transport.isPlaying())
+                {
+                    transport.stop(false, false); // TODO should this discard?
+                }
+                else
+                {
+                    transport.play(false);
+                }
             }
             break;
         }


### PR DESCRIPTION
works

log:
```[2024-11-05 01:28:28] DEBUG: APP->edit_.getTransport().getCurrentPosition(): 0.000000                                                  
[2024-11-05 01:28:28] DEBUG: APP->tracks_[APP->current_track_]->track_.getClips().size(): 0
[2024-11-05 01:28:28] DEBUG: isTrackArmed(APP->tracks_[APP->current_track_]->track_): 1                                                
[2024-11-05 01:28:28] DEBUG: trackHasInput(APP->tracks_[APP->current_track_]->track_): 1                                               
[2024-11-05 01:28:31] DEBUG: transport.getCurrentPosition(): 0.000000                                                                  
[2024-11-05 01:28:31] DEBUG: transport.isRecording(): 0
[2024-11-05 01:28:31] DEBUG: short circuited for midi input
[2024-11-05 01:28:32] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:33] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:33] DEBUG: short circuited for midi input
[2024-11-05 01:28:33] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:34] DEBUG: short circuited for midi input
[2024-11-05 01:28:34] DEBUG: short circuited for midi input
[2024-11-05 01:28:34] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:34] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:34] DEBUG: short circuited for midi input
[2024-11-05 01:28:34] DEBUG: short circuited for midi input
[2024-11-05 01:28:34] DEBUG: short circuited for midi input
[2024-11-05 01:28:34] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:34] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:35] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:35] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:35] DEBUG: short circuited for midi input   
[2024-11-05 01:28:35] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:35] DEBUG: short circuited for midi input                                                                            
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:35] DEBUG: short circuited for midi input
[2024-11-05 01:28:41] DEBUG: APP->edit_.getTransport().getCurrentPosition(): 9.336021                                                  
[2024-11-05 01:28:41] DEBUG: APP->tracks_[APP->current_track_]->track_.getClips().size(): 1                                            
[2024-11-05 01:28:41] DEBUG: isTrackArmed(APP->tracks_[APP->current_track_]->track_): 1                                                
[2024-11-05 01:28:41] DEBUG: trackHasInput(APP->tracks_[APP->current_track_]->track_): 1                                               
[2024-11-05 01:28:42] DEBUG: APP->edit_.getTransport().getCurrentPosition(): 9.336021
[2024-11-05 01:28:42] DEBUG: APP->tracks_[APP->current_track_]->track_.getClips().size(): 1
[2024-11-05 01:28:42] DEBUG: isTrackArmed(APP->tracks_[APP->current_track_]->track_): 1
[2024-11-05 01:28:42] DEBUG: trackHasInput(APP->tracks_[APP->current_track_]->track_): 1
[2024-11-05 01:28:44] DEBUG: transport.getCurrentPosition(): 9.336021
[2024-11-05 01:28:44] DEBUG: transport.isRecording(): 0
[2024-11-05 01:28:45] DEBUG: short circuited for midi input
[2024-11-05 01:28:45] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:46] DEBUG: short circuited for midi input
[2024-11-05 01:28:47] DEBUG: short circuited for midi input
[2024-11-05 01:28:47] DEBUG: short circuited for midi input
[2024-11-05 01:28:47] DEBUG: short circuited for midi input
[2024-11-05 01:28:47] DEBUG: short circuited for midi input
[2024-11-05 01:28:47] DEBUG: short circuited for midi input
[2024-11-05 01:28:48] DEBUG: transport.getCurrentPosition(): 13.549354                                                                 
[2024-11-05 01:28:48] DEBUG: transport.isRecording(): 1    
[2024-11-05 01:28:49] DEBUG: APP->edit_.getTransport().getCurrentPosition(): 13.549354                                                 
[2024-11-05 01:28:49] DEBUG: APP->tracks_[APP->current_track_]->track_.getClips().size(): 2                                            
[2024-11-05 01:28:49] DEBUG: isTrackArmed(APP->tracks_[APP->current_track_]->track_): 1                                                
[2024-11-05 01:28:49] DEBUG: trackHasInput(APP->tracks_[APP->current_track_]->track_): 1                                               
```