### PR TITLE
cursor refactor

### DIFF
--- a/include/core/timeline.hh
+++ b/include/core/timeline.hh
@@ -11,7 +11,17 @@ struct Timeline {
         Overview,
     };
 
-    te::BeatRange cursor_;
+    struct BeatRange {
+        double left_edge;
+        double right_edge;
+    };
+
+    struct Position {
+        double secs;
+        double beats;
+    };
+
+    BeatRange cursor_;
     double bar_width_ = 4.0; // Assuming a 4/4 time signature by default TODO update with time signature changes
     double step_size_ = 4.0; // Move cursor by 4 beat (1 bar)
     double radius_ = 8.0;

--- a/include/core/timeline.hh
+++ b/include/core/timeline.hh
@@ -12,19 +12,19 @@ struct Timeline {
     };
 
     struct BeatRange {
-        double left_edge;
-        double right_edge;
+        float left_edge;
+        float right_edge;
     };
 
     struct Position {
-        double secs;
-        double beats;
+        float secs;
+        float beats;
     };
 
     BeatRange cursor_;
-    double bar_width_ = 4.0; // Assuming a 4/4 time signature by default TODO update with time signature changes
-    double step_size_ = 4.0; // Move cursor by 4 beat (1 bar)
-    double radius_ = 8.0;
+    float bar_width_ = 4.0; // Assuming a 4/4 time signature by default TODO update with time signature changes
+    float step_size_ = 4.0; // Move cursor by 4 beat (1 bar)
+    float radius_ = 8.0;
     ScreenState screen_state_ = ScreenState::Overview;
     size_t scroll_offset_ = 0;
 

--- a/src/core/timeline.cc
+++ b/src/core/timeline.cc
@@ -46,8 +46,8 @@ void Timeline:: Render(Interface &interface)
         DrawRectangleRec(Rectangle{x, y, width, height}, LIGHTGRAY);
     }
 
-    // render active track TODO assert instead
-    if (curr_row < num_rows)
+    // render active track
+    assert(curr_row < num_rows);
     {
         float x = 0;
         float y = (24 * curr_row) + 32;
@@ -66,20 +66,18 @@ void Timeline:: Render(Interface &interface)
 
     // render bar lines
     {
-
-        // Time signature at current position
         const te::TimeSigSetting &time_sig = tempo.getTimeSigAt(transport.getPosition());
-        double beats_per_bar = time_sig.numerator; // Number of beats in a bar
-        double beat_length = 1.0 / time_sig.denominator; // Length of a beat in terms of whole notes
+        double beats_per_bar = time_sig.numerator;
 
-        // Start rendering bar lines from the leftmost visible beat
         double first_bar_start = std::floor(screen.left_edge / beats_per_bar) * beats_per_bar;
 
-        for (double bar_start = first_bar_start; bar_start < screen.right_edge; bar_start += beats_per_bar)
+        for (double bar_start = first_bar_start; 
+            bar_start < screen.right_edge; 
+            bar_start += beats_per_bar)
         {
             double bar_position_pct = (bar_start - screen.left_edge) / WIDTH;
             float x = static_cast<float>(bar_position_pct * 128);
-            DrawLine(x, 32, x, 32 + (24 * 4), DARKGRAY); // Full-height bar line
+            DrawLine(x, 32, x, 32 + (24 * 4), DARKGRAY);
         }
     }
 
@@ -217,7 +215,6 @@ void Timeline:: HandleEvent(const Event &event)
             case KEY_ENTER:
                 APP->screen_state_ = App::ScreenState::Track;
                 break;
-            // TODO this code is stupid fix it
             case KEY_H:
                 cursor_.left_edge -= step_size_;
                 cursor_.right_edge -= step_size_;

--- a/src/core/timeline.cc
+++ b/src/core/timeline.cc
@@ -20,21 +20,19 @@ void Timeline:: Render(Interface &interface)
 
     const size_t num_rows = std::min(APP->tracks_.size() - scroll_offset_, MAX_TRACKS);
     const size_t curr_row = APP->current_track_ - scroll_offset_;
-    const double RADIUS = radius_;
-    const double WIDTH = radius_ * 2;
+    const float RADIUS = radius_;
+    const float WIDTH = radius_ * 2;
 
     const te::TransportControl &transport = APP->edit_.getTransport();
     const te::TempoSequence &tempo = APP->edit_.tempoSequence;
 
     const Position curr_pos = {
-            APP->edit_.getTransport().getPosition().inSeconds(),
-            te::toBeats(te::EditTime{transport.getPosition()}, tempo).inBeats()
-        };
+        static_cast<float>(APP->edit_.getTransport().getPosition().inSeconds()),
+        static_cast<float>(te::toBeats(te::EditTime{transport.getPosition()}, tempo).inBeats())};
 
     const BeatRange screen = {
-            curr_pos.beats - RADIUS,
-            curr_pos.beats + RADIUS,
-        };
+        curr_pos.beats - RADIUS,
+        curr_pos.beats + RADIUS};
 
     // draw track backgrounds
     for (size_t i = 0; i < num_rows; i++)
@@ -67,15 +65,15 @@ void Timeline:: Render(Interface &interface)
     // render bar lines
     {
         const te::TimeSigSetting &time_sig = tempo.getTimeSigAt(transport.getPosition());
-        double beats_per_bar = time_sig.numerator;
+        float beats_per_bar = time_sig.numerator;
 
-        double first_bar_start = std::floor(screen.left_edge / beats_per_bar) * beats_per_bar;
+        float first_bar_start = std::floor(screen.left_edge / beats_per_bar) * beats_per_bar;
 
-        for (double bar_start = first_bar_start; 
+        for (float bar_start = first_bar_start; 
             bar_start < screen.right_edge; 
             bar_start += beats_per_bar)
         {
-            double bar_position_pct = (bar_start - screen.left_edge) / WIDTH;
+            float bar_position_pct = (bar_start - screen.left_edge) / WIDTH;
             float x = static_cast<float>(bar_position_pct * 128);
             DrawLine(x, 32, x, 32 + (24 * 4), DARKGRAY);
         }
@@ -84,11 +82,11 @@ void Timeline:: Render(Interface &interface)
     // render current live clip (if recording)
     if (transport.isRecording())
     {
-        const double start_time = tempo.toBeats(transport.getTimeWhenStarted()).inBeats();
+        const float start_time = tempo.toBeats(transport.getTimeWhenStarted()).inBeats();
         if (screen.left_edge < start_time)
         {
-            double left_pct = (start_time - screen.left_edge) / WIDTH;
-            double left_px = (left_pct * 128);
+            float left_pct = (start_time - screen.left_edge) / WIDTH;
+            float left_px = (left_pct * 128);
             DrawRectangle(left_px, (curr_row * 24) + 32, (64 - left_px), 24, RED);
         }
         else {
@@ -106,16 +104,18 @@ void Timeline:: Render(Interface &interface)
             {
                 const te::ClipPosition c_pos = c->getPosition();
                 te::BeatRange t_br = te::toBeats(c_pos.time, tempo);
-                BeatRange clip = {t_br.getStart().inBeats(), t_br.getEnd().inBeats()};
+                BeatRange clip = {
+                    static_cast<float>(t_br.getStart().inBeats()), 
+                    static_cast<float>(t_br.getEnd().inBeats())};
 
                 // Determine overlap with visible range
-                const double visible_start = std::max(screen.left_edge, clip.left_edge);
-                const double visible_end = std::min(screen.right_edge, clip.right_edge);
+                const float visible_start = std::max(screen.left_edge, clip.left_edge);
+                const float visible_end = std::min(screen.right_edge, clip.right_edge);
 
                 if (visible_start < visible_end) // Clip is visible
                 {
-                    double start_pct = (visible_start - screen.left_edge) / WIDTH;
-                    double end_pct = (visible_end - screen.left_edge) / WIDTH;
+                    float start_pct = (visible_start - screen.left_edge) / WIDTH;
+                    float end_pct = (visible_end - screen.left_edge) / WIDTH;
 
                     float left_px = static_cast<float>(start_pct * 128);
                     float right_px = static_cast<float>(end_pct * 128);
@@ -129,8 +129,8 @@ void Timeline:: Render(Interface &interface)
 
     // render cursor
     {
-        double left_pct = (cursor_.left_edge - screen.left_edge) / WIDTH;
-        double right_pct = (cursor_.right_edge - screen.left_edge) / WIDTH;
+        float left_pct = (cursor_.left_edge - screen.left_edge) / WIDTH;
+        float right_pct = (cursor_.right_edge - screen.left_edge) / WIDTH;
 
         float left_px = static_cast<float>(left_pct * 128);
         float right_px = static_cast<float>(right_pct * 128);


### PR DESCRIPTION
use simple structs instead of te::BeatRange
- enables `(double) screen.left_edge` vs. `(double) screen_left_edge.inBeats()`
- made the code a lot shorter
- might be a bad idea in the long run if i start mixing up seconds and beats...

use floats for all rendering operations
- raylib uses floats for everything, so you end up converting it anyway
- waste of memory and increases cache misses